### PR TITLE
Upgrade Libretto's OpenAI client and allows for other providers that use OpenAI 

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cohere-ai": "7.10.6",
     "mime-types": "^2.1.35",
     "nanoid": "^5.0.7",
-    "openai": "4.91.1"
+    "openai": "4.52.2"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/client-bedrock-runtime": "3.609.0",
     "@google/generative-ai": "0.14.1",
     "@libretto/anthropic": "^1.3.0",
-    "@libretto/openai": "^1.3.1",
+    "@libretto/openai": "^1.3.3",
     "@mistralai/mistralai": "0.5.0",
     "chalk": "^4.1.2",
     "cohere-ai": "7.10.6",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cohere-ai": "7.10.6",
     "mime-types": "^2.1.35",
     "nanoid": "^5.0.7",
-    "openai": "4.52.2"
+    "openai": "4.91.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(@anthropic-ai/sdk@0.24.3)(@google-cloud/dlp@5.12.0)
       '@libretto/openai':
-        specifier: ^1.3.1
-        version: 1.3.1(@google-cloud/dlp@5.12.0)(openai@4.52.2)
+        specifier: ^1.3.3
+        version: 1.3.3(@google-cloud/dlp@5.12.0)(openai@4.52.2)
       '@mistralai/mistralai':
         specifier: 0.5.0
         version: 0.5.0
@@ -1035,10 +1035,10 @@ packages:
     peerDependencies:
       '@anthropic-ai/sdk': '>0.29.0'
 
-  '@libretto/openai@1.3.1':
-    resolution: {integrity: sha512-ZDt+L47/ff0mOzV8bqV0ZTXUH1pAM1T6PG4CCdX7lnxv84SdMSPCwk6m+cxb84igW0HpVsMRqdzBpj8gxhpJxA==}
+  '@libretto/openai@1.3.3':
+    resolution: {integrity: sha512-HHnEwe25L2k9Oqo0+521c1FSfcVzCx1P+Ul8sumyFgXQ/Z+JNNBq7910wLkSCmjG0OesQTcXZvDeYc71QtvEFQ==}
     peerDependencies:
-      openai: ^4.68.4
+      openai: ^4.91.1
 
   '@libretto/redact-pii-light@1.0.1':
     resolution: {integrity: sha512-fWt6m/V7Tm49lQA/PZ/Qkwufh4bSQgUDc2Nc/POSkMIc/faICEv3L3IM/m2YIqXtaTd59EElFMV2Dd3gC5nPbw==}
@@ -3185,9 +3185,6 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
-  just-performance@4.3.0:
-    resolution: {integrity: sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==}
-
   jwa@2.0.0:
     resolution: {integrity: sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==}
 
@@ -3209,8 +3206,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  limiter@2.1.0:
-    resolution: {integrity: sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw==}
+  limiter@3.0.0:
+    resolution: {integrity: sha512-hev7DuXojsTFl2YwyzUJMDnZ/qBDd3yZQLSH3aD4tdL1cqfc3TMnoecEJtWFaQFdErZsKoFMBTxF/FBSkgDbEg==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -3446,6 +3443,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -4230,6 +4231,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
 snapshots:
 
@@ -5804,12 +5809,12 @@ snapshots:
     transitivePeerDependencies:
       - '@google-cloud/dlp'
 
-  '@libretto/openai@1.3.1(@google-cloud/dlp@5.12.0)(openai@4.52.2)':
+  '@libretto/openai@1.3.3(@google-cloud/dlp@5.12.0)(openai@4.52.2)':
     dependencies:
       '@libretto/redact-pii-light': 1.0.1(@google-cloud/dlp@5.12.0)
-      limiter: 2.1.0
+      limiter: 3.0.0
       openai: 4.52.2
-      p-limit: 3.1.0
+      p-limit: 6.2.0
       p-queue: 6.6.2
     transitivePeerDependencies:
       - '@google-cloud/dlp'
@@ -8690,8 +8695,6 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
-  just-performance@4.3.0: {}
-
   jwa@2.0.0:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -8716,9 +8719,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  limiter@2.1.0:
-    dependencies:
-      just-performance: 4.3.0
+  limiter@3.0.0: {}
 
   lines-and-columns@1.2.4: {}
 
@@ -8938,6 +8939,10 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.1
 
   p-locate@4.1.0:
     dependencies:
@@ -9806,3 +9811,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.3.0(@anthropic-ai/sdk@0.24.3)(@google-cloud/dlp@5.12.0)
       '@libretto/openai':
         specifier: ^1.3.3
-        version: 1.3.3(@google-cloud/dlp@5.12.0)(openai@4.91.1)
+        version: 1.3.3(@google-cloud/dlp@5.12.0)(openai@4.52.2)
       '@mistralai/mistralai':
         specifier: 0.5.0
         version: 0.5.0
@@ -39,8 +39,8 @@ importers:
         specifier: ^5.0.7
         version: 5.0.9
       openai:
-        specifier: 4.91.1
-        version: 4.91.1
+        specifier: 4.52.2
+        version: 4.52.2
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.18.2
@@ -3409,17 +3409,9 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openai@4.91.1:
-    resolution: {integrity: sha512-DbjrR0hIMQFbxz8+3qBsfPJnh3+I/skPgoSlT7f9eiZuhGBUissPQULNgx6gHNkLoZ3uS0uYS6eXPUdtg4nHzw==}
+  openai@4.52.2:
+    resolution: {integrity: sha512-mMc0XgFuVSkcm0lRIi8zaw++otC82ZlfkCur1qguXYWPETr/+ZwL9A/vvp3YahX+shpaT6j03dwsmUyLAfmEfg==}
     hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5817,11 +5809,11 @@ snapshots:
     transitivePeerDependencies:
       - '@google-cloud/dlp'
 
-  '@libretto/openai@1.3.3(@google-cloud/dlp@5.12.0)(openai@4.91.1)':
+  '@libretto/openai@1.3.3(@google-cloud/dlp@5.12.0)(openai@4.52.2)':
     dependencies:
       '@libretto/redact-pii-light': 1.0.1(@google-cloud/dlp@5.12.0)
       limiter: 3.0.0
-      openai: 4.91.1
+      openai: 4.52.2
       p-limit: 6.2.0
       p-queue: 6.6.2
     transitivePeerDependencies:
@@ -8902,7 +8894,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@4.91.1:
+  openai@4.52.2:
     dependencies:
       '@types/node': 18.19.75
       '@types/node-fetch': 2.6.12
@@ -8911,6 +8903,7 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+      web-streams-polyfill: 3.3.3
     transitivePeerDependencies:
       - encoding
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.3.0(@anthropic-ai/sdk@0.24.3)(@google-cloud/dlp@5.12.0)
       '@libretto/openai':
         specifier: ^1.3.3
-        version: 1.3.3(@google-cloud/dlp@5.12.0)(openai@4.52.2)
+        version: 1.3.3(@google-cloud/dlp@5.12.0)(openai@4.91.1)
       '@mistralai/mistralai':
         specifier: 0.5.0
         version: 0.5.0
@@ -39,8 +39,8 @@ importers:
         specifier: ^5.0.7
         version: 5.0.9
       openai:
-        specifier: 4.52.2
-        version: 4.52.2
+        specifier: 4.91.1
+        version: 4.91.1
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.18.2
@@ -3409,9 +3409,17 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openai@4.52.2:
-    resolution: {integrity: sha512-mMc0XgFuVSkcm0lRIi8zaw++otC82ZlfkCur1qguXYWPETr/+ZwL9A/vvp3YahX+shpaT6j03dwsmUyLAfmEfg==}
+  openai@4.91.1:
+    resolution: {integrity: sha512-DbjrR0hIMQFbxz8+3qBsfPJnh3+I/skPgoSlT7f9eiZuhGBUissPQULNgx6gHNkLoZ3uS0uYS6eXPUdtg4nHzw==}
     hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5809,11 +5817,11 @@ snapshots:
     transitivePeerDependencies:
       - '@google-cloud/dlp'
 
-  '@libretto/openai@1.3.3(@google-cloud/dlp@5.12.0)(openai@4.52.2)':
+  '@libretto/openai@1.3.3(@google-cloud/dlp@5.12.0)(openai@4.91.1)':
     dependencies:
       '@libretto/redact-pii-light': 1.0.1(@google-cloud/dlp@5.12.0)
       limiter: 3.0.0
-      openai: 4.52.2
+      openai: 4.91.1
       p-limit: 6.2.0
       p-queue: 6.6.2
     transitivePeerDependencies:
@@ -8894,7 +8902,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@4.52.2:
+  openai@4.91.1:
     dependencies:
       '@types/node': 18.19.75
       '@types/node-fetch': 2.6.12
@@ -8903,7 +8911,6 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
-      web-streams-polyfill: 3.3.3
     transitivePeerDependencies:
       - encoding
 

--- a/src/handlers/groq.ts
+++ b/src/handlers/groq.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai'
+import { OpenAI } from '@libretto/openai'
 
 import { GroqModel, ProviderCompletionParams } from '../chat/index.js'
 import {

--- a/src/handlers/openai-compatible.ts
+++ b/src/handlers/openai-compatible.ts
@@ -1,4 +1,5 @@
-import OpenAI from 'openai'
+import { OpenAI } from '@libretto/openai'
+import { ChatCompletionChunk } from 'openai/resources/chat/completions'
 import { Stream } from 'openai/streaming'
 
 import {
@@ -14,7 +15,7 @@ import { BaseHandler } from './base.js'
 import { InputError } from './types.js'
 
 async function* streamOpenAI(
-  response: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
+  response: Stream<ChatCompletionChunk>
 ): StreamCompletionResponse {
   for await (const chunk of response) {
     yield chunk

--- a/src/handlers/openrouter.ts
+++ b/src/handlers/openrouter.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'openai'
+import { OpenAI } from '@libretto/openai'
 
 import { OpenRouterModel, ProviderCompletionParams } from '../chat/index.js'
 import {

--- a/src/handlers/perplexity.ts
+++ b/src/handlers/perplexity.ts
@@ -1,4 +1,5 @@
-import OpenAI from 'openai'
+import { OpenAI } from '@libretto/openai'
+import { ChatCompletionChunk } from 'openai/resources/chat/completions'
 import { Stream } from 'openai/streaming'
 
 import { PerplexityModel, ProviderCompletionParams } from '../chat/index.js'
@@ -12,7 +13,7 @@ import { InputError } from './types.js'
 export const PERPLEXITY_PREFIX = 'perplexity/'
 
 async function* streamPerplexity(
-  response: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
+  response: Stream<ChatCompletionChunk>
 ): StreamCompletionResponse {
   for await (const chunk of response) {
     yield chunk


### PR DESCRIPTION
This upgrades the `@libretto/openai` library, and also replaces it where I should have replaced the base openai client in other places like `groq`.